### PR TITLE
Xcode files with xcode9.3

### DIFF
--- a/Threadly.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Threadly.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Threadly.xcodeproj/xcshareddata/xcschemes/Threadly iOS.xcscheme
+++ b/Threadly.xcodeproj/xcshareddata/xcschemes/Threadly iOS.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Threadly.xcodeproj/xcshareddata/xcschemes/Threadly macOS.xcscheme
+++ b/Threadly.xcodeproj/xcshareddata/xcschemes/Threadly macOS.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Threadly.xcodeproj/xcshareddata/xcschemes/Threadly tvOS.xcscheme
+++ b/Threadly.xcodeproj/xcshareddata/xcschemes/Threadly tvOS.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
With Xcode9.3, If I change `Show` checkbox on scheme management window,
Xcode make a this file.

I use this library by gitsubmodule + carthage and add xcodeproj to xcworkspace for application development.
So this diff makes work repository state dirty.
Please merge this.

It similar to 
https://github.com/nvzqz/RandomKit/pull/57
https://github.com/nvzqz/ShiftOperations/pull/1

By the way, I made this PR for master branch.
But your `RandomKit` points `v1.0.0` of `Threadly`.

So I want same patch for `v1.0.0` actually.
But there is a possibility to update `Threadly` for `RandomKit`.
How do you think?
